### PR TITLE
CSS : cosmetics

### DIFF
--- a/app/assets/views/candidat.html
+++ b/app/assets/views/candidat.html
@@ -150,6 +150,7 @@
           <!-- Desciption  content -->
         <div class="tab-content">
           <div role="tabpanel" class="tab-pane" id="admin-infos">
+            <h3>Infos</h3>
             <div class="person">
               <p>
                 Né(e) en {{country.codeToCountry[artist.user.profile.birthplace_country]}} le {{ artist.user.profile.birthdate }}

--- a/app/assets/views/partials/candidat_card.html
+++ b/app/assets/views/partials/candidat_card.html
@@ -1,4 +1,4 @@
-<div class="candidat-card col-md-6"  ng-class="{
+<div class="candidat-card col-lg-6"  ng-class="{
         'ghost': !candidature.application_completed,
         'showing_details': $parent.$parent.candidat_id == candidature.id,
         'application_complete': candidature.application_complete,
@@ -24,9 +24,10 @@
             </div>
             <div class="col-xs-8 col-md-8 no-gutter">
               <div class="row">
-                <div class="col-xs-8 col-md-8">
+                <div class="col-xs-10 col-md-10">
                   <div class="user-infos">
                     <div>
+                        <span class="candidature-number">{{candidature.current_year_application_count}}</span>
                       <span class="user-last_name preserve-info">{{ candidature.artist.user.last_name }}</span>
                       <span class="oneline nationality hide-infos">
                         <span ng-repeat="nationality in candidature.artist.user.profile.nationality.split(', ') track by $index">
@@ -44,13 +45,13 @@
                     </div>
                   </div>
                 </div>
-                <div class="col-xs-4 col-md-4 .no-gutter">
+                <div class="col-xs-2 col-md-2 .no-gutter">
                   <div class="candidature-infos-icon">
                     <div ng-if="candidature.selected_for_interview && !candidature.wait_listed && !candidature.selected"><i class="btn-lg glyphicon glyphicon-user grey"></i></div>
                     <div ng-if="candidature.wait_listed && !candidature.selected"><i class="btn-lg glyphicon glyphicon-ok grey"></i></div>
                     <div ng-if="candidature.selected"><i class="btn-lg glyphicon glyphicon-ok green"></i></div>
                   </div>
-                  <span class="candidature-number">{{candidature.current_year_application_count}}</span>
+                  
                 </div>
               </div>
             </div>

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -473,6 +473,10 @@ body.en {
   .candidature-infos-icon{
     // height: 60px;
     // line-height: 90px;
+    position: relative;
+    margin-top: 50px;
+    right: 10px;
+    
     .glyphicon{
       font-size:28px;
       padding: 0px;

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -1,3 +1,11 @@
+html {
+    font-size: 100%;
+}
+
+body {
+    font-size: 1rem;
+}
+
 .modal-dialog{
     min-width: 90%;
 
@@ -392,10 +400,26 @@ body.en {
 
 
 .candidat-card{
-  font-size: 0.9em;
-  height: 110px;
+  font-size: 1rem;
+  height: 150px;
   margin: 20px 0px;
 
+    .user-infos {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        height: 100%;
+        & > div { 
+            flex: 1 0 100%;
+            padding-bottom: 5px; 
+        }
+        & div:first-child { padding: 0px; }
+        .langues {
+            margin-top: 5px;
+        }
+    }
+    
+        
   .corner{
     position: absolute;
     right: 15px;
@@ -424,12 +448,12 @@ body.en {
     text-transform:uppercase;
   }
   .user-first_name, .user-last_name, .user-birthdate{
-    font-size: 10pt;
+    font-size: 1rem;
     line-height: 10pt;
   }
   .langues{
-    font-size: 8pt;
-    line-height: 12pt;
+    font-size: .8rem;
+    line-height: .8rem;
     color: #4a4a4a;
     .language:after{
       content:",";
@@ -441,13 +465,14 @@ body.en {
   .candidature-number{
     text-align: right;
     text-align-last: right;
-    font-size: 0.8em;
-
+    font-size: 0.8rem;
+    display: inline-block;
+    min-width: 100%;
   }
 
   .candidature-infos-icon{
-    height: 60px;
-    line-height: 90px;
+    // height: 60px;
+    // line-height: 90px;
     .glyphicon{
       font-size:28px;
       padding: 0px;
@@ -504,7 +529,7 @@ body.en {
       visibility: hidden;
     }
     .preserve-info:before{
-      content: "XXXXX";
+      content: "";
       position: absolute;
       visibility: visible;
     }
@@ -515,7 +540,7 @@ body.en {
       background: #4a4a4a;
       text-align: right;
       position: absolute;
-      left: -5px;
+      left: 0;
       color:white;
     }
     .user-birthdate{display: none}
@@ -545,8 +570,8 @@ body.en {
     white-space:nowrap;
   }
   .flag-icon{
-    height: 10px;
-    width: 20px;
+    height: 15px;
+    width: 30px;
   }
   .row > div{
     overflow: hidden;
@@ -645,6 +670,7 @@ body.en {
   height: 80%;
   display: block;
   .candidat{
+    
 
     .flag-icon{
       width: 100px;


### PR DESCRIPTION
Candidates' cards (list of applications) and individual candidate's view lightly redesigned with more space for content

We are a bit stuck with old versions of bootstrap and deprecated CSS conventions, but Kartel is still quite responsive. The PR tries to give more space for textual content and fix a missing title "Infos" on the first tab content ("Infos"). Along the way, I converted fonts units (_px_,_pt_) to _rem_.